### PR TITLE
Allow special characters in channel names as allowed by pusher.com

### DIFF
--- a/lib/pusher.js
+++ b/lib/pusher.js
@@ -121,7 +121,7 @@ Pusher.prototype.trigger = function(channels, event, data, socketId, callback) {
     if (channels[i].length > 200) {
       throw new Error("Too long channel name: '" + channels[i] + "'");
     }
-    if (!channels[i].match(/^[a-zA-Z0-9_\-]+$/)) {
+    if (!channels[i].match(/^[a-zA-Z0-9_\-=@,.;]+$/)) {
       throw new Error("Invalid channel name: '" + channels[i] + "'");
     }
   }


### PR DESCRIPTION
As stated by the [pusher.com documentation](https://pusher.com/docs/client_api_guide/client_channels#naming-channels), you may use `_ - = @ , . ; ` in your channel names.

closes pusher/pusher-rest-node#5