### PR TITLE
use utf-8 string encoding

### DIFF
--- a/lib/token.js
+++ b/lib/token.js
@@ -19,7 +19,7 @@ function Token(key, secret) {
  * @returns {String}
  */
 Token.prototype.sign = function(string) {
-  return crypto.createHmac('sha256', this.secret).update(string).digest('hex');
+  return crypto.createHmac('sha256', this.secret).update(new Buffer(string, 'utf-8')).digest('hex');
 };
 
 /** Checks if the string has correct signature.


### PR DESCRIPTION
Allow more characters to be used in presenceData (like é, ü, â, etc...) by using utf-8 encoding.